### PR TITLE
Add xrefs to GO terms

### DIFF
--- a/sparql/construct_GO_AmiGO.sparql
+++ b/sparql/construct_GO_AmiGO.sparql
@@ -1,0 +1,15 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX VFBd: <http://virtualflybrain.org/reports/>
+
+CONSTRUCT { ?x oio:hasDbXref VFBd:AmiGO .
+	[ rdf:type owl:Axiom ;
+   owl:annotatedSource ?x ;
+   owl:annotatedProperty oio:hasDbXref ;
+   owl:annotatedTarget VFBd:AmiGO ;
+   <http://n2o.neo/custom/accession> ?id ] . }
+WHERE { ?x oio:id ?id
+  FILTER REGEX(?id, "GO:[0-9]+") . }
+
+

--- a/sparql/construct_GO_FB_vocab.sparql
+++ b/sparql/construct_GO_FB_vocab.sparql
@@ -1,0 +1,15 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX VFBd: <http://virtualflybrain.org/reports/>
+
+CONSTRUCT { ?x oio:hasDbXref VFBd:FlyBase_vocabularies .
+	[ rdf:type owl:Axiom ;
+   owl:annotatedSource ?x ;
+   owl:annotatedProperty oio:hasDbXref ;
+   owl:annotatedTarget VFBd:FlyBase_vocabularies ;
+   <http://n2o.neo/custom/accession> ?id ] . }
+WHERE { ?x oio:id ?id
+  FILTER REGEX(?id, "GO:[0-9]+") . }
+
+

--- a/sparql/construct_GO_QuickGO.sparql
+++ b/sparql/construct_GO_QuickGO.sparql
@@ -1,0 +1,15 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX VFBd: <http://virtualflybrain.org/reports/>
+
+CONSTRUCT { ?x oio:hasDbXref VFBd:QuickGO .
+	[ rdf:type owl:Axiom ;
+   owl:annotatedSource ?x ;
+   owl:annotatedProperty oio:hasDbXref ;
+   owl:annotatedTarget VFBd:QuickGO ;
+   <http://n2o.neo/custom/accession> ?id ] . }
+WHERE { ?x oio:id ?id
+  FILTER REGEX(?id, "GO:[0-9]+") . }
+
+


### PR DESCRIPTION
construct queries to add links to AmiGO, QuickGO and FB Vocabularies using oio:id as accession
related to #41