### PR TITLE
Side loading CSV file name postfixes added

### DIFF
--- a/dumps.Makefile
+++ b/dumps.Makefile
@@ -231,7 +231,7 @@ $(RAW_DUMPS_DIR)/side_loads.owl: $(patsubst %, $(RAW_DUMPS_DIR)/%, $(PDB_EXTERNA
 # Generates the side loading CSV files for the PDB
 pdb_sideloads: $(RAW_DUMPS_DIR)/side_loads.owl | $(CSV_IMPORTS)
         echo $@ started: `date +%s` >> $(LOG_FILE)
-	java $(ROBOT_ARGS) -jar $(OWL2NEOCSV) $< "none" $(CSV_IMPORTS) false $(INFER_ANNOTATE_RELATION)
+	java $(ROBOT_ARGS) -jar $(OWL2NEOCSV) $< "none" $(CSV_IMPORTS) false $(INFER_ANNOTATE_RELATION) "side_load"
 	echo $@ ended: `date +%s` >> $(LOG_FILE)
 
 # Generates the CSV files for the PDB and imports them into Neo4j.


### PR DESCRIPTION
Uses the new cli parameter (https://github.com/VirtualFlyBrain/neo4j2owl/pull/93) to add name postfix to side loaded ontology csv exports