### PR TITLE
Explain reasoner failures in the dumps build

### DIFF
--- a/dumps.Makefile
+++ b/dumps.Makefile
@@ -14,6 +14,28 @@ define log
     @echo $1 ended: `date +%s` >> $(LOG_FILE)
 endef
 
+# When `robot reason` fails it prints a single line -- "The ontology is inconsistent"
+# or a count of unsatisfiable classes -- and nothing about which axioms caused it, so a
+# 2.5 hour build ends with no way to act on the result. This runs `robot explain` over
+# the same input, and only when reason has already failed, so a green build pays nothing
+# for it. Both modes are tried because the two failures need different ones: an ABox
+# contradiction is only visible to --mode inconsistency, unsatisfiable classes only to
+# --mode unsatisfiability. `-u root` names the classes that cause the rest rather
+# than sampling consequences.
+#
+# The `|| true` on each explain is deliberate and scoped to the diagnostic: a failure to
+# explain must never replace or mask the real error. The caller adds a trailing `false`
+# so the build still fails.
+EXPLAIN_ALL = echo "===== robot explain: inconsistency (ABox) =====" ; \
+	$(ROBOT) explain -i $(RAW_DUMPS_DIR)/all.ttl --reasoner ELK --mode inconsistency \
+		-m 5 -e $(RAW_DUMPS_DIR)/explain_inconsistency.md || true ; \
+	cat $(RAW_DUMPS_DIR)/explain_inconsistency.md 2>/dev/null || true ; \
+	echo "===== robot explain: unsatisfiable classes (root causes) =====" ; \
+	$(ROBOT) explain -i $(RAW_DUMPS_DIR)/all.ttl --reasoner ELK --mode unsatisfiability \
+		-u root -m 1 -e $(RAW_DUMPS_DIR)/explain_unsatisfiability.md || true ; \
+	cat $(RAW_DUMPS_DIR)/explain_unsatisfiability.md 2>/dev/null || true ; \
+	echo "===== end robot explain ====="
+
 # Suggest parallel execution in comments
 # To speed up the build process, you can run make with parallel jobs: `make -j 4 all`
 
@@ -76,7 +98,7 @@ $(RAW_DUMPS_DIR)/construct_%.owl: $(RAW_DUMPS_DIR)/%.ttl
 # Generates an OWL file from multiple TTL files, infers annotations and relations,
 # reduces the ontology, annotates it, and saves it to disk.
 $(RAW_DUMPS_DIR)/construct_all.owl: $(RAW_DUMPS_DIR)/all.ttl
-	$(call log, $@, $(ROBOT) merge -i $< reason --reasoner ELK --axiom-generators "SubClass EquivalentClass ClassAssertion" --exclude-tautologies structural relax reduce --reasoner ELK annotate --ontology-iri "http://virtualflybrain.org/data/VFB/OWL/raw/all.owl" convert -f owl -o $@ $(STDOUT_FILTER))
+	$(call log, $@, $(ROBOT) merge -i $< reason --reasoner ELK --axiom-generators "SubClass EquivalentClass ClassAssertion" --exclude-tautologies structural relax reduce --reasoner ELK annotate --ontology-iri "http://virtualflybrain.org/data/VFB/OWL/raw/all.owl" convert -f owl -o $@ $(STDOUT_FILTER) || { $(EXPLAIN_ALL) ; false ; })
 
 # Infers annotations and relations for the virtual fly brain ontology using the ROBOT inference engine.
 $(RAW_DUMPS_DIR)/inferred_annotation.owl: $(FINAL_DUMPS_DIR)/owlery.owl $(RAW_DUMPS_DIR)/vfb-config.yaml


### PR DESCRIPTION
## What

`robot reason` reports a failed `construct_all.owl` in a single line — `The ontology is inconsistent`, or a count of unsatisfiable classes — and names no axioms. Each failure therefore costs a full build (2 h 31 m on #879 and #880) to learn nothing actionable.

This runs `robot explain` over the same `all.ttl` from the failure branch of that one recipe, so the console carries the derivation that caused it.

## Why this shape

- **Failure branch only.** The explain is appended as `|| { $(EXPLAIN_ALL) ; false ; }`, so a green build does no extra reasoning and costs nothing. The trailing `false` re-raises the failure, so the build still fails exactly as before.
- **Both modes.** They are not interchangeable: an ABox contradiction is only visible to `--mode inconsistency`, and unsatisfiable classes only to `--mode unsatisfiability`. Recent builds have hit both.
- **`-u root`** names the classes that cause the rest rather than sampling consequences. With ~19,832 unsatisfiable classes descending from one bad pair, a random sample is almost all consequence.
- The `|| true` on each explain is deliberate and scoped to the diagnostic — a failure to explain must never replace or mask the real error.

## How to test

Both paths were exercised against ROBOT 1.8.3 (the version pinned in the Dockerfile) with the real recipe and the real `STDOUT_FILTER`, using a stub `all.ttl`:

- **Inconsistent input** — `reason` emits `ERROR The ontology is inconsistent`, the explain then prints the three axioms responsible, and `make` still exits 1.
- **Unsatisfiable input** — `reason` lists the unsatisfiable classes, and the explain prints the derivation for the root ones, e.g.

```
## genomic feature (GENO_0000481) SubClassOf Nothing ##
  - GENO_0000481 EquivalentTo SO_0000110 and (GENO_0000903 some GENO_0000902)
    - SO_0000110 SubClassOf BFO_0000040
      - BFO_0000040 SubClassOf BFO_0000004
    - SO_0000110 SubClassOf GENO_0000701
      - GENO_0000701 SubClassOf BFO_0000031
  - BFO_0000004 DisjointWith BFO_0000031
```

Explanations are also written to `$(RAW_DUMPS_DIR)/explain_inconsistency.md` and `explain_unsatisfiability.md`.

## Follow-ups, not in this PR

- The job's log grep is `grep -E 'Killed|Error|curie|make: \*\*\*'`, which matches `Error` but not `ERROR`, so it catches the real error line only incidentally via the `make: ***` pattern. That lives in the Jenkins job config rather than this repo.
- On a failing build the explain adds a second reasoning pass, so a failure gets slower. That seemed the right trade against a blind 2½-hour cycle, but it is worth watching.
